### PR TITLE
Linux support

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -47,6 +47,30 @@
             "cwd": "${workspaceFolder}",
             "environment": [],
             "externalConsole": false
+          },
+          {
+            "name": "Linux Launch",
+            "type": "cppdbg",
+            "request": "launch",
+            "program": "${workspaceFolder}/build/28_model_loading",
+            "args": [],
+            "stopAtEntry": false,
+            "cwd": "${workspaceFolder}",
+            "environment": [],
+            "externalConsole": false,
+            "MIMode": "gdb",
+            "setupCommands": [
+                {
+                    "description": "Enable pretty-printing for gdb",
+                    "text": "-enable-pretty-printing",
+                    "ignoreFailures": true
+                },
+                {
+                    "description": "Set Disassembly Flavor to Intel",
+                    "text": "-gdb-set disassembly-flavor intel",
+                    "ignoreFailures": true
+                }
+            ]
           }
     ]
 

--- a/28_model_loading.cpp
+++ b/28_model_loading.cpp
@@ -26,7 +26,7 @@
 #define VMA_IMPLEMENTATION
 //#define VMA_STATIC_VULKAN_FUNCTIONS 0
 #define VMA_DYNAMIC_VULKAN_FUNCTIONS 1
-#include "vma/vk_mem_alloc.h"
+#include "vk_mem_alloc.h"
 
 #define IMGUI_IMPL_VULKAN_USE_VOLK
 #include "imgui.h"

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -9,36 +9,42 @@ project (
 set(CMAKE_CXX_STANDARD 20)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
+message("Compiler: " ${CMAKE_CXX_COMPILER_ID})
+
 add_compile_definitions(_CRT_SECURE_NO_WARNINGS)
-if (CMAKE_CXX_COMPILER_ID STREQUAL "MSVC")
-	#add_compile_options(/EHsc /DEBUG /Zi /Istb) #for assimp
-elseif(CMAKE_CXX_COMPILER_ID STREQUAL "AppleClang")
-	add_compile_options(-Wno-nullability-completeness)
-elseif(CMAKE_CXX_COMPILER_ID STREQUAL "Clang")
-	add_compile_options(-Wno-nullability-completeness)
-elseif(CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
+if (NOT CMAKE_CXX_COMPILER_ID STREQUAL "MSVC")
 	add_compile_options(-Wno-nullability-completeness)
 endif()
 
+#--------------------------------- Find VulkanSDK ---------------------------------#
 find_package(Vulkan REQUIRED)
 message("Vulkan_INCLUDE_DIR: " ${Vulkan_INCLUDE_DIR})
-message("Vulkan_LIBRARY: " ${Vulkan_LIBRARY})
 
+#--------------------------------- Find SDL2 ---------------------------------#
 set(VULKAN $ENV{VULKAN_SDK}) #set to Vulkan SDK
 message("VULKAN SDK: " ${VULKAN})
-list(APPEND CMAKE_PREFIX_PATH ${VULKAN})
-find_package(SDL2 REQUIRED)
-
-message("Compiler: " ${CMAKE_CXX_COMPILER_ID})
+if (APPLE)
+	# Vulkan SDK on Mac does not provide SDL2Config.cmake
+	add_library(SDL2::SDL2 SHARED IMPORTED)
+	set_target_properties(SDL2::SDL2 PROPERTIES
+	    INTERFACE_INCLUDE_DIRECTORIES ${VULKAN}/include/SDL2
+		IMPORTED_LOCATION ${VULKAN}/lib/libSDL2-2.0.dylib
+	)
+else()
+	# search SDL2 in Vulkan SDK and system packages
+	list(APPEND CMAKE_PREFIX_PATH ${VULKAN})
+	find_package(SDL2 REQUIRED)
+endif()
+# available now as SDL2::SDL2
 
 #--------------------------------- Fetch ImGui ---------------------------------#
 include(FetchContent) # enable Fetch Content
-
 FetchContent_Declare(imgui
                      GIT_REPOSITORY https://github.com/ocornut/imgui.git 
                      GIT_TAG master)
 
 FetchContent_MakeAvailable(Imgui)
+# ImGui does not provide CMakeLists.txt
 add_library(imgui)
 target_include_directories(imgui SYSTEM PUBLIC ${imgui_SOURCE_DIR} ${imgui_SOURCE_DIR}/backends)
 target_include_directories(imgui SYSTEM PRIVATE ${Vulkan_INCLUDE_DIRS})
@@ -54,12 +60,14 @@ target_sources(imgui PRIVATE
 	${imgui_SOURCE_DIR}/backends/imgui_impl_vulkan.cpp
 )
 
+#--------------------------------- Fetch vk-bootstrap ---------------------------------#
 FetchContent_Declare(vkbootstrap
                      GIT_REPOSITORY https://github.com/charles-lunarg/vk-bootstrap.git 
                      GIT_TAG main)
 FetchContent_MakeAvailable(vkbootstrap)
+# available now as vk-bootstrap::vk-bootstrap
 
-
+#--------------------------------- Main Target ---------------------------------#
 set(TARGET 28_model_loading)
 
 set(SOURCE

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -9,53 +9,27 @@ project (
 set(CMAKE_CXX_STANDARD 20)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
+add_compile_definitions(_CRT_SECURE_NO_WARNINGS)
 if (CMAKE_CXX_COMPILER_ID STREQUAL "MSVC")
-  	add_compile_options(/D IMGUI_IMPL_VULKAN_NO_PROTOTYPES)
-	add_compile_options(/D_CRT_SECURE_NO_WARNINGS) #for assimp
-	add_compile_options(/EHsc /std:c++20 /DEBUG /Zi /Istb) #for assimp
+	#add_compile_options(/EHsc /DEBUG /Zi /Istb) #for assimp
 elseif(CMAKE_CXX_COMPILER_ID STREQUAL "AppleClang")
-	add_compile_options(-D IMGUI_IMPL_VULKAN_NO_PROTOTYPES)
 	add_compile_options(-Wno-nullability-completeness)
-	add_compile_options(-D_CRT_SECURE_NO_WARNINGS) #for assimp
 elseif(CMAKE_CXX_COMPILER_ID STREQUAL "Clang")
-	add_compile_options(-D IMGUI_IMPL_VULKAN_NO_PROTOTYPES)
 	add_compile_options(-Wno-nullability-completeness)
-	add_compile_options(-D_CRT_SECURE_NO_WARNINGS) #for assimp
 elseif(CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
-	add_compile_options(-D IMGUI_IMPL_VULKAN_NO_PROTOTYPES)
 	add_compile_options(-Wno-nullability-completeness)
-	add_compile_options(-D_CRT_SECURE_NO_WARNINGS) #for assimp
-endif()
-
-if (WIN32)
-	set(SDKINCLUDE Include)
-	set(SDKLIB Lib)
-	set(SDL2LIB SDL2.lib)
-  	set(VOLKLIB volk.lib)
-  	set(VKBLIB vk-bootstrap.lib)
-elseif (APPLE)
-	set(SDKINCLUDE include)
-    set(SDKLIB lib)
-	set(SDL2LIB libSDL2-2.0.dylib)
-  	set(VOLKLIB libvolk.a)
-  	set(VKBLIB libvk-bootstrap.a)
-elseif (UNIX)
-	set(SDKINCLUDE include)
-	set(SDKLIB lib)
-	set(SDL2LIB libSDL2-2.0.a)
-  	set(VOLKLIB libvolk.a)
-  	set(VKBLIB libvk-bootstrap.a)
 endif()
 
 find_package(Vulkan REQUIRED)
+message("Vulkan_INCLUDE_DIR: " ${Vulkan_INCLUDE_DIR})
+message("Vulkan_LIBRARY: " ${Vulkan_LIBRARY})
+
 set(VULKAN $ENV{VULKAN_SDK}) #set to Vulkan SDK
 message("VULKAN SDK: " ${VULKAN})
-message("SDKINCLUDE: " ${SDKINCLUDE})
-message("SDKLIB: " ${SDKLIB})
-message("Compiler: " ${CMAKE_CXX_COMPILER_ID})
+list(APPEND CMAKE_PREFIX_PATH ${VULKAN})
+find_package(SDL2 REQUIRED)
 
-set(BUILD ${PROJECT_SOURCE_DIR}/build)  # engine include directory
-set(INCLUDE ${PROJECT_SOURCE_DIR}/include)  # engine include directory
+message("Compiler: " ${CMAKE_CXX_COMPILER_ID})
 
 #--------------------------------- Fetch ImGui ---------------------------------#
 include(FetchContent) # enable Fetch Content
@@ -63,8 +37,22 @@ include(FetchContent) # enable Fetch Content
 FetchContent_Declare(imgui
                      GIT_REPOSITORY https://github.com/ocornut/imgui.git 
                      GIT_TAG master)
+
 FetchContent_MakeAvailable(Imgui)
-set(IMGUI ${imgui_SOURCE_DIR})
+add_library(imgui)
+target_include_directories(imgui SYSTEM PUBLIC ${imgui_SOURCE_DIR} ${imgui_SOURCE_DIR}/backends)
+target_include_directories(imgui SYSTEM PRIVATE ${Vulkan_INCLUDE_DIRS})
+target_compile_definitions(imgui PRIVATE IMGUI_IMPL_VULKAN_NO_PROTOTYPES)
+target_link_libraries(imgui SDL2::SDL2)
+target_sources(imgui PRIVATE
+	${imgui_SOURCE_DIR}/imgui.cpp
+	${imgui_SOURCE_DIR}/imgui_draw.cpp
+	${imgui_SOURCE_DIR}/imgui_widgets.cpp
+	${imgui_SOURCE_DIR}/imgui_tables.cpp
+	${imgui_SOURCE_DIR}/imgui_demo.cpp
+	${imgui_SOURCE_DIR}/backends/imgui_impl_sdl2.cpp
+	${imgui_SOURCE_DIR}/backends/imgui_impl_vulkan.cpp
+)
 
 FetchContent_Declare(vkbootstrap
                      GIT_REPOSITORY https://github.com/charles-lunarg/vk-bootstrap.git 
@@ -75,31 +63,15 @@ FetchContent_MakeAvailable(vkbootstrap)
 set(TARGET 28_model_loading)
 
 set(SOURCE
-  ${IMGUI}/imgui.cpp
-  ${IMGUI}/imgui_demo.cpp
-  ${IMGUI}/imgui_draw.cpp
-  ${IMGUI}/backends/imgui_impl_sdl2.cpp
-  ${IMGUI}/backends/imgui_impl_vulkan.cpp
-  ${IMGUI}/imgui_tables.cpp
-  ${IMGUI}/imgui_widgets.cpp
   28_model_loading.cpp
-  )
+)
 
 set(HEADERS )
 
 add_executable(${TARGET} ${SOURCE} ${HEADERS})
 
-target_include_directories(${TARGET} PUBLIC stb)
-target_include_directories(${TARGET} PUBLIC ${VULKAN}/${SDKINCLUDE})
-target_include_directories(${TARGET} PUBLIC ${VULKAN}/${SDKINCLUDE}/SDL2)
-target_include_directories(${TARGET} PUBLIC ${VULKAN}/${SDKINCLUDE}/volk)
-target_include_directories(${TARGET} PUBLIC ${VULKAN}/${SDKINCLUDE}/glm)
-target_include_directories(${TARGET} PUBLIC ${VULKAN}/${SDKINCLUDE}/vma)
-target_include_directories(${TARGET} PUBLIC ${IMGUI})
-target_include_directories(${TARGET} PUBLIC ${IMGUI}/backends)
-target_include_directories(${TARGET} PUBLIC ${vkbootstrap_SOURCE_DIR}/src)
-
-target_link_libraries (${TARGET} PUBLIC ${VULKAN}/${SDKLIB}/${SDL2LIB})
-target_link_libraries (${TARGET} PUBLIC ${VULKAN}/${SDKLIB}/${VOLKLIB})
-target_link_libraries (${TARGET} PUBLIC ${vkbootstrap_BINARY_DIR}/${VKBLIB})
-
+target_include_directories(${TARGET} PRIVATE stb)
+target_include_directories(${TARGET} PRIVATE ${Vulkan_INCLUDE_DIR}/volk)
+target_include_directories(${TARGET} PRIVATE ${Vulkan_INCLUDE_DIR}/vma)
+target_include_directories(${TARGET} SYSTEM PRIVATE ${Vulkan_INCLUDE_DIRS})
+target_link_libraries(${TARGET} PRIVATE SDL2::SDL2 vk-bootstrap::vk-bootstrap imgui)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,9 +1,9 @@
 cmake_minimum_required (VERSION 3.5.0)
 project (
-  "28_model_loading"
-  VERSION 2.0.0
-  DESCRIPTION "A game engine using the Vulkan API"
-  LANGUAGES CXX
+    "28_model_loading"
+    VERSION 2.0.0
+    DESCRIPTION "A game engine using the Vulkan API"
+    LANGUAGES CXX
 )
 
 set(CMAKE_CXX_STANDARD 20)
@@ -13,7 +13,7 @@ message("Compiler: " ${CMAKE_CXX_COMPILER_ID})
 
 add_compile_definitions(_CRT_SECURE_NO_WARNINGS)
 if (NOT CMAKE_CXX_COMPILER_ID STREQUAL "MSVC")
-	add_compile_options(-Wno-nullability-completeness)
+    add_compile_options(-Wno-nullability-completeness)
 endif()
 
 #--------------------------------- Find VulkanSDK ---------------------------------#
@@ -21,19 +21,19 @@ find_package(Vulkan REQUIRED)
 message("Vulkan_INCLUDE_DIR: " ${Vulkan_INCLUDE_DIR})
 
 #--------------------------------- Find SDL2 ---------------------------------#
-set(VULKAN $ENV{VULKAN_SDK}) #set to Vulkan SDK
+set(VULKAN $ENV{VULKAN_SDK}) #set to Vulkan SDK; needed to find SDL2 if installed with Vulkan SDK
 message("VULKAN SDK: " ${VULKAN})
 if (APPLE)
-	# Vulkan SDK on Mac does not provide SDL2Config.cmake
-	add_library(SDL2::SDL2 SHARED IMPORTED)
-	set_target_properties(SDL2::SDL2 PROPERTIES
-	    INTERFACE_INCLUDE_DIRECTORIES ${VULKAN}/include/SDL2
-		IMPORTED_LOCATION ${VULKAN}/lib/libSDL2-2.0.dylib
-	)
+    # Vulkan SDK on Mac does not provide SDL2Config.cmake
+    add_library(SDL2::SDL2 SHARED IMPORTED)
+    set_target_properties(SDL2::SDL2 PROPERTIES
+        INTERFACE_INCLUDE_DIRECTORIES ${VULKAN}/include/SDL2
+        IMPORTED_LOCATION ${VULKAN}/lib/libSDL2-2.0.dylib
+    )
 else()
-	# search SDL2 in Vulkan SDK and system packages
-	list(APPEND CMAKE_PREFIX_PATH ${VULKAN})
-	find_package(SDL2 REQUIRED)
+    # search SDL2 in Vulkan SDK and system packages
+    list(APPEND CMAKE_PREFIX_PATH ${VULKAN})
+    find_package(SDL2 REQUIRED)
 endif()
 # available now as SDL2::SDL2
 
@@ -51,14 +51,15 @@ target_include_directories(imgui SYSTEM PRIVATE ${Vulkan_INCLUDE_DIRS})
 target_compile_definitions(imgui PRIVATE IMGUI_IMPL_VULKAN_NO_PROTOTYPES)
 target_link_libraries(imgui SDL2::SDL2)
 target_sources(imgui PRIVATE
-	${imgui_SOURCE_DIR}/imgui.cpp
-	${imgui_SOURCE_DIR}/imgui_draw.cpp
-	${imgui_SOURCE_DIR}/imgui_widgets.cpp
-	${imgui_SOURCE_DIR}/imgui_tables.cpp
-	${imgui_SOURCE_DIR}/imgui_demo.cpp
-	${imgui_SOURCE_DIR}/backends/imgui_impl_sdl2.cpp
-	${imgui_SOURCE_DIR}/backends/imgui_impl_vulkan.cpp
+    ${imgui_SOURCE_DIR}/imgui.cpp
+    ${imgui_SOURCE_DIR}/imgui_draw.cpp
+    ${imgui_SOURCE_DIR}/imgui_widgets.cpp
+    ${imgui_SOURCE_DIR}/imgui_tables.cpp
+    ${imgui_SOURCE_DIR}/imgui_demo.cpp
+    ${imgui_SOURCE_DIR}/backends/imgui_impl_sdl2.cpp
+    ${imgui_SOURCE_DIR}/backends/imgui_impl_vulkan.cpp
 )
+# available now as imgui
 
 #--------------------------------- Fetch vk-bootstrap ---------------------------------#
 FetchContent_Declare(vkbootstrap
@@ -71,7 +72,7 @@ FetchContent_MakeAvailable(vkbootstrap)
 set(TARGET 28_model_loading)
 
 set(SOURCE
-  28_model_loading.cpp
+    28_model_loading.cpp
 )
 
 set(HEADERS )

--- a/README.md
+++ b/README.md
@@ -67,6 +67,24 @@ On Windows compile using MSVC and the compile.cmd file. Make sure to first clone
    - Use cmake directly to configure and compile
    - Or use MS Visual Studio Code, see below (recommended).
 
+# Installing on Linux
+
+1. **Install Dependencies:**  
+   On Ubuntu 24.10 you need following packages (install using `apt`):  
+   `build-essential git cmake libvulkan-dev vulkan-validationlayers libsdl2-dev libglm-dev libvulkan-volk-dev libvulkan-memory-allocator-dev`  
+   If you use another distribution please install equivalent packages.
+
+2. **Configure and Compile**  
+   ```sh
+   cmake -B build
+   cmake --build build
+   ```
+
+3. **Run**
+   ```sh
+   build/28_model_loading
+   ```
+
 # Using MS Visual Studio Code
 
 If you want to use MS Visual Studio Code (available for most platforms), install it for your platform. Also install the extensions Cmake an Cmake Tools. Then you can access all cmake features by clicking on Menu View / Command Palette... and enter cmake. You will be presented the cmake options which you can choose from in this sequence:

--- a/compile.cmd
+++ b/compile.cmd
@@ -1,6 +1,6 @@
 
 set IMGUI="C:\data\GitHub\ViennaVulkanEngine\extern\imgui"
-echo %IMGUI%
+set VKBOOTSTRAP="C:\data\vkbootstrap"
 set VULKAN=%VULKAN_SDK%
 rem set VULKAN="C:\VulkanSDK\
 echo %VULKAN%
@@ -18,6 +18,8 @@ cl 28_model_loading.cpp ^
     /I%VULKAN%\include ^
     /I%VULKAN%\include\SDL2 ^
     /I%VULKAN%\include\volk ^
+    /I%VULKAN%\include\vma ^
+    /I%VKBOOTSTRAP%\src ^
     %VULKAN%\Lib\SDL2.lib ^
     %VULKAN%\Lib\volk.lib ^
     /link /SUBSYSTEM:CONSOLE /OUT:28_model_loading.exe


### PR DESCRIPTION
Changes:
- merged support for Linux (provided by Daniel Fichter)
- changed cmake to use library targets where possible
- added vkbootstrap to compile.cmd

Tested on:
- Windows (MSVC x64)
- Mac (Clang ARM64 on M2)
- Linux (GCC ARM64 on RaspberryPi 5)
- WSL2 (WSLg in Docker)